### PR TITLE
Update in README - 16577 => 13577

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ FRONTEND_URL=http://localhost:13577 \
   npm run start
 ```
 
-The app should then be available at http://localhost:16577.
+The app should then be available at http://localhost:13577.
 
 ### Debugging
 


### PR DESCRIPTION
Considering, that the value of bash script as `FRONTEND_URL` passed to `webpack.config.js` and `port` part will be used from bash script.
Just to be consistent among README.